### PR TITLE
Implementation of Java 21 virtual threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
@@ -36,11 +32,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/bartoszthielmann/gitapi/config/ThreadConfig.java
+++ b/src/main/java/com/bartoszthielmann/gitapi/config/ThreadConfig.java
@@ -1,0 +1,31 @@
+package com.bartoszthielmann.gitapi.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.embedded.tomcat.TomcatProtocolHandlerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.support.TaskExecutorAdapter;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executors;
+
+@EnableAsync
+@Configuration
+@ConditionalOnProperty(
+        value = "spring.thread-executor",
+        havingValue = "virtual"
+)
+public class ThreadConfig {
+    @Bean
+    public AsyncTaskExecutor applicationTaskExecutor() {
+        return new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
+    }
+
+    @Bean
+    public TomcatProtocolHandlerCustomizer<?> protocolHandlerVirtualThreadExecutorCustomizer() {
+        return protocolHandler -> {
+            protocolHandler.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
+        };
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 github.baseUrl=https://api.github.com
+
+# "virtual" to enable Virtual Threads
+spring.thread-executor=virtual

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,5 @@
 wiremock.port=8089
 github.baseUrl=http://localhost:8089
+
+# "virtual" to enable Virtual Threads
+spring.thread-executor=virtual


### PR DESCRIPTION
Implemented virtual threads using TaskExecutorAdapter and TomcatProtocolHandlerCustomizer.

Another solution would be to use spring.threads.virtual.enabled property, but for now going with Configuration class.